### PR TITLE
chore: mescla setup inicial do Terraform da develop para main

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ projeto_pipeline/
 
 1. **Clonar o Repositório**:
    ```bash
-   git clone <URL_DO_REPOSITORIO>
+   git clone https://github.com/aremartins/data-engineering-project.git
    cd projeto_pipeline/infra/terraform
   
 

--- a/readme.md
+++ b/readme.md
@@ -4,17 +4,16 @@
 Este projeto configura uma infraestrutura de dados na AWS utilizando Terraform. A infraestrutura inclui a criação de buckets S3 para armazenamento de dados brutos e resultados de consultas do Athena, além da configuração de roles e policies no IAM para permitir que o AWS Glue execute tarefas de ETL.
 
 ## Estrutura do Projeto
+```plaintext
 projeto_pipeline/
 ├── infra/
-│ └── terraform/
-│ ├── main.tf
-│ ├── providers.tf
-│ ├── variables.tf
-│ └── outputs.tf
+│   └── terraform/
+│       ├── main.tf
+│       ├── providers.tf
+│       ├── variables.tf
+│       └── outputs.tf
 └── scripts/
-
-markdown
-Copy code
+```
 
 ## Pré-requisitos
 - Conta na AWS
@@ -27,17 +26,16 @@ Copy code
    ```bash
    git clone <URL_DO_REPOSITORIO>
    cd projeto_pipeline/infra/terraform
-Configurar Credenciais AWS:
-Certifique-se de que suas credenciais AWS estão configuradas corretamente. Você pode fazer isso usando o comando:
-
-    aws configure
+  
 
 2. **Configurar Credenciais AWS**:
     Certifique-se de que suas credenciais AWS estão configuradas corretamente. Você pode fazer isso usando o comando:
-    
+    aws configure
+
+3. **Inicializar o Terraform**:    
     terraform init
 
-3. **Planear e Aplicar as Mudanças**:
+4. **Planejar e Aplicar as Mudanças**:
     Planeje as mudanças e depois aplique-as:
     
     terraform plan
@@ -46,14 +44,16 @@ Certifique-se de que suas credenciais AWS estão configuradas corretamente. Voc�
 ## Recursos Criados
 
 ### Buckets S3:
-
+```plaintext
 my-company-data-raw-transactions
 my-company-data-raw-customers
 my-company-data-raw-logs
 my-company-data-athena-results
-Roles e Policies IAM:
+```
 
-### AWSGlueServiceRole com a policy AWSGlueServicePolicy anexada.
+### Roles e Policies IAM:
+
+ AWSGlueServiceRole com a policy AWSGlueServicePolicy anexada.
 
 
 ## Verificação dos Recursos


### PR DESCRIPTION
Este PR mescla o setup inicial do Terraform, desenvolvido na branch `develop`, para a branch `main`. Esta configuração provisiona a infraestrutura necessária na AWS, incluindo buckets S3 e roles/policies no IAM para o AWS Glue.

### Mudanças Principais
- Adiciona `main.tf` com definição de recursos S3 e IAM
- Adiciona `providers.tf` para configurar o provedor AWS
- Adiciona `variables.tf` para definir variáveis reutilizáveis
- Adiciona `outputs.tf` para definir saídas do Terraform

### Testes Realizados
- Testes locais com `terraform plan` e `terraform apply` para verificar a criação correta dos recursos
- Verificação manual no Console da AWS para garantir que os recursos foram provisionados corretamente

### Checklist
- [x] Código compilado e testado
- [x] Documentação atualizada

